### PR TITLE
Update emulator screenshot method

### DIFF
--- a/src/pyclashbot/detection/image_rec.py
+++ b/src/pyclashbot/detection/image_rec.py
@@ -6,7 +6,7 @@ import cv2
 import numpy as np
 
 from pyclashbot.memu.client import screenshot
-from pyclashbot.utils.image_handler import open_image
+from pyclashbot.utils.image_handler import open_from_path
 
 
 def get_file_count(folder) -> int:
@@ -114,7 +114,7 @@ def find_references(
     top_level = dirname(__file__)
     reference_folder = abspath(join(top_level, "reference_images", folder))
 
-    reference_images = [open_image(join(reference_folder, name)) for name in names]
+    reference_images = [open_from_path(join(reference_folder, name)) for name in names]
 
     with ThreadPoolExecutor(
         max_workers=len(reference_images), thread_name_prefix="EmulatorThread"

--- a/src/pyclashbot/memu/client.py
+++ b/src/pyclashbot/memu/client.py
@@ -1,12 +1,11 @@
 """Module for interacting with the memu client"""
 
-import os
 import time
 
 from numpy import ndarray
 from pymemuc import PyMemuc, PyMemucError
 
-from pyclashbot.utils.image_handler import InvalidImageError, open_image
+from pyclashbot.utils.image_handler import InvalidImageError, open_from_bytes
 
 pmc = PyMemuc(debug=False)
 
@@ -21,16 +20,16 @@ def screenshot(vm_index: int) -> ndarray:
         numpy.ndarray: Screenshot of the given region
     """
     try:
-        image_name = f"screenshot{vm_index}.png"
-        picture_path = pmc.get_configuration_vm(
-            vm_index=vm_index, config_key="picturepath"
-        ).replace('"', "")
-        image_path = os.path.join(picture_path, image_name)
-        pmc.send_adb_command_vm(
+        # read screencap from vm using screencap output encoded in base64
+        img_b64 = pmc.send_adb_command_vm(
             vm_index=vm_index,
-            command=f"exec-out screencap -p /sdcard/pictures/{image_name}",
+            command="exec-out screencap -p | base64",
         )
-        return open_image(image_path)
+        # decode base64
+        img_bytearray = bytearray(img_b64, "utf-8")
+        # open image from bytearray
+        return open_from_bytes(img_bytearray)
+        # return open_image(image_path)
 
     except (PyMemucError, FileNotFoundError, InvalidImageError):
         time.sleep(0.1)
@@ -61,8 +60,6 @@ def scroll_up(vm_index):
 def scroll_up_on_left_side_of_screen(vm_index):
     """Method for scrolling up faster when interacting with a scrollable menu"""
     send_swipe(vm_index, 66, 300, 66, 400)
-
-
 
 
 def scroll_down(vm_index):

--- a/src/pyclashbot/memu/launcher.py
+++ b/src/pyclashbot/memu/launcher.py
@@ -8,8 +8,7 @@ import contextlib
 import subprocess
 import sys
 import time
-from os import makedirs
-from os.path import exists, expandvars, join
+from os.path import join
 
 import numpy
 import psutil
@@ -51,9 +50,7 @@ def restart_emulator(logger, start_time=time.time()):
     while time_waiting < MANUAL_VM_WAIT_TIME:
         time.sleep(4)
         time_waiting = time.time() - wait_start_time
-        logger.change_status(
-            (f"Waiting for VM to load {str(time_waiting)[:2]}")
-        )
+        logger.change_status((f"Waiting for VM to load {str(time_waiting)[:2]}"))
 
     # skip ads
     # logger.change_status("Skipping ads")
@@ -185,15 +182,6 @@ def set_vm_language(vm_index: int):
         time.sleep(0.1)
 
 
-def get_screenshot_folder() -> str:
-    """Get the path to the screenshot folder"""
-    screenshot_path = join(expandvars("%appdata%"), "py-clash-bot", "screenshots")
-    # make sure this folder exists
-    if not exists(screenshot_path):
-        makedirs(screenshot_path)
-    return screenshot_path
-
-
 def configure_vm(logger: Logger, vm_index):
     logger.change_status(status="Configuring VM")
 
@@ -219,7 +207,6 @@ def configure_vm(logger: Logger, vm_index):
         "turbo_mode": "0",
         "enable_audio": "0",
         "is_hide_toolbar": "1",
-        "picturepath": get_screenshot_folder(),
     }
 
     for key, value in configuration.items():

--- a/src/pyclashbot/utils/image_handler.py
+++ b/src/pyclashbot/utils/image_handler.py
@@ -13,14 +13,14 @@ class InvalidImageError(Exception):
         super().__init__(self.message)
 
 
-def open_from_bytes(byte_array: bytearray) -> np.ndarray:
+def open_from_bytes(image_data: bytes) -> np.ndarray:
     """
     A method to read an image from a byte array
     :param byte_array: the byte array to read the image from
     :return: the image as a numpy array
     :raises InvalidImageError: if the file is not a valid image
     """
-    im_arr = np.asarray(byte_array, dtype=np.uint8)
+    im_arr = np.frombuffer(image_data, dtype=np.uint8)
     img = cv2.imdecode(im_arr, cv2.IMREAD_COLOR)  # pylint: disable=no-member
     if img is None:
         raise InvalidImageError("Byte array is not a valid image")

--- a/src/pyclashbot/utils/image_handler.py
+++ b/src/pyclashbot/utils/image_handler.py
@@ -7,13 +7,29 @@ import numpy as np
 class InvalidImageError(Exception):
     """Exception raised when an image is invalid"""
 
-    def __init__(self, path: str, message: str):
+    def __init__(self, message: str, path: str = None):
         self.path = path
         self.message = message
         super().__init__(self.message)
 
 
-def open_image(path: str) -> np.ndarray:
+def open_from_bytes(byte_array: bytearray) -> np.ndarray:
+    """
+    A method to read an image from a byte array
+    :param byte_array: the byte array to read the image from
+    :return: the image as a numpy array
+    :raises InvalidImageError: if the file is not a valid image
+    """
+    im_arr = np.asarray(byte_array, dtype=np.uint8)
+    img = cv2.imdecode(im_arr, cv2.IMREAD_COLOR)  # pylint: disable=no-member
+    if img is None:
+        raise InvalidImageError("Byte array is not a valid image")
+    if np.all(img == 255):
+        raise InvalidImageError("Byte array is not a valid image. All pixels are white")
+    return img
+
+
+def open_from_path(path: str) -> np.ndarray:
     """
     A method to validate and open an image file
     :param path: the path to the image file
@@ -26,14 +42,9 @@ def open_image(path: str) -> np.ndarray:
         raise FileNotFoundError(f"File {path} does not exist")
     if not path.lower().endswith(".png"):
         raise ValueError(f"File {path} is not a png image")
-    with open(path, "rb") as im_stream:  # sourcery skip: extract-method
+    with open(path, "rb") as im_stream:
         im_bytes = bytearray(im_stream.read())
-        im_arr = np.asarray(im_bytes, dtype=np.uint8)
-        img = cv2.imdecode(im_arr, cv2.IMREAD_COLOR)  # pylint: disable=no-member
-        if img is None:
-            raise InvalidImageError(path, f"File {path} is not a valid image")
-        if np.all(img == 255):
-            raise InvalidImageError(
-                path, f"File {path} is not a valid image. All pixels are white"
-            )
-        return img
+        try:
+            return open_from_bytes(im_bytes)
+        except InvalidImageError as error:
+            raise InvalidImageError(f"File {path} is not a valid image") from error


### PR DESCRIPTION
Pipe the output from the screencap execution directly into memory, skipping file creation, opening and validation.